### PR TITLE
Missing object in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This [dbt package](https://docs.getdbt.com/docs/package-management):
     - transactions
     - subsidiaries
     - vendors
+    - vendor_types
 
 
 ## Installation instructions


### PR DESCRIPTION
Vendor Types is required to run the transaction_details model