### PR TITLE
Fix converted_amount in balance sheet

### DIFF
--- a/models/netsuite2/netsuite2__balance_sheet.sql
+++ b/models/netsuite2/netsuite2__balance_sheet.sql
@@ -65,9 +65,12 @@ balance_sheet as (
     {{ fivetran_utils.persist_pass_through_columns('accounts_pass_through_columns', identifier='accounts') }},
 
     case
-      when not accounts.is_balancesheet or lower(transactions_with_converted_amounts.account_category) = 'equity' then -converted_amount_using_transaction_accounting_period
-      when not accounts.is_leftside then -converted_amount_using_reporting_month
-      when accounts.is_leftside then converted_amount_using_reporting_month
+      when not accounts.is_balancesheet and lower(accounts.general_rate_type) in ('historical', 'average') then -converted_amount_using_transaction_accounting_period
+      when not accounts.is_balancesheet then -converted_amount_using_reporting_month
+      when accounts.is_balancesheet and not accounts.is_leftside and lower(accounts.general_rate_type) in ('historical', 'average') then -converted_amount_using_transaction_accounting_period
+      when accounts.is_balancesheet and accounts.is_leftside and lower(accounts.general_rate_type) in ('historical', 'average') then converted_amount_using_transaction_accounting_period
+      when accounts.is_balancesheet and not accounts.is_leftside then -converted_amount_using_reporting_month
+      when accounts.is_balancesheet and accounts.is_leftside then converted_amount_using_reporting_month
       else 0
         end as converted_amount,
     


### PR DESCRIPTION
Translation based on general_rate_type instead of account_category.

**Please provide your name and company**
Jared Monger, Lyra Health

**Link the issue/feature request which this PR is meant to address**
https://github.com/fivetran/dbt_netsuite/issues/75

**Detail what changes this PR introduces and how this addresses the issue/feature request linked above.**
This change fixes a currency translation issue in the balance sheet table. In order to match the NetSuite balance sheet report, accounts should translate based on the `general_rate_type` rather than the `account_category`.

**How did you validate the changes introduced within this PR?**
First, we materialized the balance sheet table with this change incorporated. Next, we summarized the results by `account_type_name` and reconciled to the NetSuite balance sheet report.

**Which warehouse did you use to develop these changes?**
Snowflake

**Did you update the CHANGELOG?**
<!--- Please update the new package version’s CHANGELOG entry detailing the changes included in this PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes

**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)**
<!--- The dbt_project.yml and the integration_tests/dbt_project.yml files contain the version number. Be sure to upgrade it accordingly -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
:metal:

**Feedback**
Appreciate the collaboration from the Fivetran team.
