### PR TITLE
DECISIONLOG re: null converted amounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# dbt_netsuite v0.13.0
+
 # dbt_netsuite v0.12.0
 ## 🎁 Official release for Netsuite2! 🎁
 [PR #98](https://github.com/fivetran/dbt_netsuite/pull/98) is the official supported release of [dbt_netsuite v0.12.0-b1](https://github.com/fivetran/dbt_netsuite/releases/tag/v0.12.0-b1). 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   - item_id
   - transaction_number
 
+## 📝 Documentation Update 📝
+- [Updated DECISIONLOG](https://github.com/fivetran/dbt_netsuite/blob/main/DECISIONLOG.md#why-converted-transaction-amounts-are-null-if-they-are-non-posting) with our reasoning for why we don't bring in future-facing transactions and leave the `converted_amount` in transaction details empty. ([#115](https://github.com/fivetran/dbt_netsuite/issues/115))
 ## Contributors:
 - [@FrankTub](https://github.com/FrankTub) ([#114](https://github.com/fivetran/dbt_netsuite/issues/114))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,18 @@
 # dbt_netsuite v0.13.0
+[PR #114](https://github.com/fivetran/dbt_netsuite/pull/114) includes the following updates:
+
+## 🎉 Features
+- Added the following columns to model `netsuite2__transaction_details`:
+  - department_id
+  - entity_id
+  - is_closed
+  - is_main_line
+  - is_tax_line
+  - item_id
+  - transaction_number
+
+## Contributors:
+- [@FrankTub](https://github.com/FrankTub) ([#114](https://github.com/fivetran/dbt_netsuite/issues/114))
 
 # dbt_netsuite v0.12.0
 ## 🎁 Official release for Netsuite2! 🎁

--- a/DECISIONLOG.md
+++ b/DECISIONLOG.md
@@ -9,3 +9,11 @@ In the `int_netsuite__transactions_with_converted_amounts` model, account types 
 ## Creation of 'Other' Account Category for Non Posting and Statistical Account Types
 
 As mentioned above, in the `int_netsuite__transactions_with_converted_amounts`/`int_netsuite2_tran_with_converted_amounts` models, account types are bucketed into broader account _categories_. There is no standard category for `Non Posting` and `Statistical` account types and transactions from these kinds of accounts are excluded from all financial reports. However, they are used for other workflows in Netsuite, so we have bucketed `Non Posting` and `Statistical` account types into a new `Other` account category.
+
+## Why converted transaction amounts are null if they are non-posting
+
+In our `intermediate` Netsuite models, we translate amounts from posted transactions into their proper `converted_amount` values based on the exchange rates in the reporting and transaction periods. That way, customers will always have accurate `converted_amount` data that can help them validate their financial reporting.
+
+For the sake of financial fidelity, we decided not to convert amounts that are non-posting because the exchange rates are subject to change. While that can provide additional value for customers looking to do financial forecasting, we do not want to create confusion by bringing in converted transactions that have amounts that are variable to change, and disrupt existing financial reporting processes.
+
+For customers interested in creating future-facing `converted_amount` values, our recommendation would be to materialize the `intermediate` tables to grab the exchange rate data in your internal warehouse, then leverage the `transaction_amount` in these particular cases to produce the future `converted_amounts`.

--- a/models/netsuite2.yml
+++ b/models/netsuite2.yml
@@ -304,3 +304,17 @@ models:
       tests:
           - unique
           - not_null
+    - name: department_id
+      description: "{{ doc('department_id') }}"
+    - name: entity_id
+      description: "{{ doc('entity_id') }}"
+    - name: is_closed
+      description: Boolean indicating if the accounting period is closed.
+    - name: is_main_line
+      description: Boolean indicating if the transaction line is a main line entry.
+    - name: is_tax_line
+      description: Boolean indicating if the transaction line is a tax line..
+    - name: item_id
+      description: "{{ doc('item_id') }}"
+    - name: transaction_number
+      description: The Netsuite generated number of the transaction.

--- a/models/netsuite2/netsuite2__transaction_details.sql
+++ b/models/netsuite2/netsuite2__transaction_details.sql
@@ -94,11 +94,16 @@ transaction_details as (
     transaction_lines.transaction_line_id,
     transaction_lines.memo as transaction_memo,
     not transaction_lines.is_posting as is_transaction_non_posting,
+    transaction_lines.is_main_line,
+    transaction_lines.is_tax_line,
+    transaction_lines.is_closed,
     transactions.transaction_id,
     transactions.status as transaction_status,
     transactions.transaction_date,
     transactions.due_date_at as transaction_due_date,
     transactions.transaction_type as transaction_type,
+    transactions.transaction_number,
+    coalesce(transaction_lines.entity_id, transactions.entity_id) as entity_id,
     transactions.is_intercompany_adjustment as is_transaction_intercompany_adjustment
 
     --The below script allows for transactions table pass through columns.
@@ -136,6 +141,7 @@ transaction_details as (
     customers.date_first_order_at as customer_date_first_order,
     customers.customer_external_id,
     classes.full_name as class_full_name,
+    transaction_lines.item_id,
     items.name as item_name,
     items.type_name as item_type_name,
     items.sales_description,
@@ -149,6 +155,7 @@ transaction_details as (
     vendors.create_date_at as vendor_create_date,
     currencies.name as currency_name,
     currencies.symbol as currency_symbol,
+    transaction_lines.department_id,
     departments.name as department_name
 
     --The below script allows for departments table pass through columns.


### PR DESCRIPTION
## PR Overview
**This PR will address the following Issue/Feature:** [#

**This PR will result in the following new package version:**
<!--- Please add details around your decision for breaking vs non-breaking version upgrade. If this is a breaking change, were backwards-compatible options explored? -->

**Please provide the finalized CHANGELOG entry which details the relevant changes included in this PR:**
<!--- Copy/paste the CHANGELOG for this version below. -->
## 📝 Documentation Update 📝
- [Updated DECISIONLOG](https://github.com/fivetran/dbt_netsuite/blob/main/DECISIONLOG.md#why-converted-transaction-amounts-are-null-if-they-are-non-posting) with our reasoning for why we don't bring in future-facing transactions and leave the `converted_amount` in transaction details empty. ([#115](https://github.com/fivetran/dbt_netsuite/issues/115))
- 
## PR Checklist
### Basic Validation
Please acknowledge that you have successfully performed the following commands locally:
- [NA] dbt run –full-refresh && dbt test
- [NA] dbt run (if incremental models are present)

Before marking this PR as "ready for review" the following have been applied:
- [x] The appropriate issue has been linked, tagged, and properly assigned
- [x] -All necessary documentation and version upgrades have been applied
- [NA] docs were regenerated (unless this PR does not include any code or yml updates)
- [x] BuildKite integration tests are passing
- [x] Detailed validation steps have been provided below

### Detailed Validation
Please share any and all of your validation steps:
<!--- Provide the steps you took to validate your changes below. -->

Just a documentation update
